### PR TITLE
Refactor OpenAI target to use native Codable models

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,15 +29,6 @@
       }
     },
     {
-      "identity" : "swift-openai-responses",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftedMind/swift-openai-responses",
-      "state" : {
-        "branch" : "main",
-        "revision" : "fd6c3f6a0909266bb50e6d16cec3a9fbf79245d7"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",

--- a/Package.swift
+++ b/Package.swift
@@ -10,34 +10,36 @@ let package = Package(
 	products: [
 		.library(name: "OpenAISession", targets: ["OpenAISession", "SimulatedSession", "SwiftAgent"]),
 	],
-	dependencies: [
-		.package(url: "https://github.com/SwiftedMind/swift-openai-responses", branch: "main"),
-	],
-	targets: [
-		.target(
-			name: "Internal",
-		),
-		.target(
+        dependencies: [],
+        targets: [
+                .target(
+                        name: "Internal",
+                ),
+                .target(
 			name: "SwiftAgent",
 			dependencies: ["Internal"],
 		),
 		.target(
 			name: "OpenAISession",
-			dependencies: [
-				"SwiftAgent",
-				.product(name: "OpenAI", package: "swift-openai-responses"),
-			],
-			path: "Sources/OpenAI",
-		),
-		.target(
-			name: "SimulatedSession",
-			dependencies: [
-				"SwiftAgent",
-				"Internal",
-				.product(name: "OpenAI", package: "swift-openai-responses"),
-			],
-			path: "Sources/Simulation",
-		),
+                        dependencies: [
+                                "SwiftAgent",
+                                "OpenAI",
+                        ],
+                        path: "Sources/OpenAI",
+                ),
+                .target(
+                        name: "OpenAI",
+                        path: "Sources/OpenAIModels",
+                ),
+                .target(
+                        name: "SimulatedSession",
+                        dependencies: [
+                                "SwiftAgent",
+                                "Internal",
+                                "OpenAI",
+                        ],
+                        path: "Sources/Simulation",
+                ),
 		.testTarget(
 			name: "SwiftAgentTests",
 			dependencies: ["SwiftAgent"],

--- a/Sources/OpenAIModels/Input.swift
+++ b/Sources/OpenAIModels/Input.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+/// Text, image, or file inputs to the Responses API.
+public enum Input: Sendable {
+  public enum ListItem: Sendable {
+    case message(Message.Input)
+    case item(Item.Input)
+    case itemRef(id: String)
+  }
+
+  public enum Content: Sendable {
+    public enum ContentItem: Sendable {
+      case text(String)
+    }
+
+    case text(String)
+    case list([ContentItem])
+  }
+
+  case text(String)
+  case list([ListItem])
+}
+
+// MARK: - Codable
+
+extension Input: Codable {
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case let .text(value):
+      var container = encoder.singleValueContainer()
+      try container.encode(value)
+    case let .list(items):
+      var container = encoder.unkeyedContainer()
+      for item in items {
+        try container.encode(item)
+      }
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    if let stringValue = try? decoder.singleValueContainer().decode(String.self) {
+      self = .text(stringValue)
+      return
+    }
+
+    var container = try decoder.unkeyedContainer()
+    var items: [ListItem] = []
+    while !container.isAtEnd {
+      let item = try container.decode(ListItem.self)
+      items.append(item)
+    }
+    self = .list(items)
+  }
+}
+
+extension Input.ListItem: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case id
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .message(message):
+      try container.encode("message", forKey: .type)
+      try message.encode(to: encoder)
+    case let .item(item):
+      try container.encode(item.typeIdentifier, forKey: .type)
+      try item.encode(to: encoder)
+    case let .itemRef(id):
+      try container.encode("item_reference", forKey: .type)
+      try container.encode(id, forKey: .id)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "message":
+      let message = try Message.Input(from: decoder)
+      self = .message(message)
+    case "item_reference":
+      let identifier = try container.decode(String.self, forKey: .id)
+      self = .itemRef(id: identifier)
+    default:
+      let item = try Item.Input(from: decoder, type: type)
+      self = .item(item)
+    }
+  }
+}
+
+extension Input.Content: Codable {
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case let .text(text):
+      var container = encoder.unkeyedContainer()
+      try container.encode(ContentItem.text(text))
+    case let .list(items):
+      var container = encoder.unkeyedContainer()
+      for item in items {
+        try container.encode(item)
+      }
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    if let stringValue = try? decoder.singleValueContainer().decode(String.self) {
+      self = .text(stringValue)
+      return
+    }
+
+    var container = try decoder.unkeyedContainer()
+    var items: [ContentItem] = []
+    while !container.isAtEnd {
+      let item = try container.decode(ContentItem.self)
+      items.append(item)
+    }
+
+    if items.count == 1, case let .text(text) = items[0] {
+      self = .text(text)
+    } else {
+      self = .list(items)
+    }
+  }
+}
+
+extension Input.Content.ContentItem: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case text
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .text(text):
+      try container.encode("input_text", forKey: .type)
+      try container.encode(text, forKey: .text)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "input_text":
+      let text = try container.decode(String.self, forKey: .text)
+      self = .text(text)
+    default:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported content item type \(type)."))
+    }
+  }
+}
+
+// MARK: - Helpers
+
+public extension Input.ListItem {
+  static func message(role: Message.Role = .user, content: Input.Content, status: Message.Status? = nil) -> Self {
+    .message(Message.Input(role: role, content: content, status: status))
+  }
+
+  static func item(_ item: Item.Input) -> Self {
+    .item(item)
+  }
+}
+
+public extension Input.Content {
+  static func text(_ text: String) -> Input.Content {
+    .text(text)
+  }
+
+  var text: String? {
+    switch self {
+    case let .text(value):
+      return value
+    case let .list(items):
+      let pieces = items.compactMap { item -> String? in
+        if case let .text(text) = item {
+          return text
+        }
+        return nil
+      }
+      return pieces.isEmpty ? nil : pieces.joined(separator: " ")
+    }
+  }
+}

--- a/Sources/OpenAIModels/Item.swift
+++ b/Sources/OpenAIModels/Item.swift
@@ -1,0 +1,442 @@
+import Foundation
+
+/// Items that form part of a model response or prompt history.
+public enum Item: Sendable {
+  public enum Input: Sendable {
+    case inputMessage(Message.Input)
+    case outputMessage(Message.Output)
+    case functionCall(FunctionCall)
+    case functionCallOutput(FunctionCallOutput)
+    case reasoning(Reasoning)
+
+    var typeIdentifier: String {
+      switch self {
+      case .inputMessage, .outputMessage:
+        return "message"
+      case .functionCall:
+        return "function_call"
+      case .functionCallOutput:
+        return "function_call_output"
+      case .reasoning:
+        return "reasoning"
+      }
+    }
+  }
+
+  public enum Output: Sendable {
+    public enum Content: Sendable {
+      public enum Annotation: Hashable, Sendable {
+        case fileCitation(fileId: String, index: UInt)
+        case urlCitation(endIndex: UInt, startIndex: UInt, title: String, url: String)
+        case filePath(fileId: String, index: UInt)
+      }
+
+      public struct LogProb: Codable, Hashable, Sendable {
+        public struct AlternativeLogProb: Codable, Hashable, Sendable {
+          public var bytes: [Int]
+          public var logprob: Double
+          public var token: String
+
+          public init(bytes: [Int], logprob: Double, token: String) {
+            self.bytes = bytes
+            self.logprob = logprob
+            self.token = token
+          }
+        }
+
+        public var bytes: [Int]
+        public var token: String
+        public var logprob: Double
+        public var topLogprobs: [AlternativeLogProb]?
+
+        public init(bytes: [Int], token: String, logprob: Double, topLogprobs: [AlternativeLogProb]? = nil) {
+          self.bytes = bytes
+          self.token = token
+          self.logprob = logprob
+          self.topLogprobs = topLogprobs
+        }
+
+        private enum CodingKeys: String, CodingKey {
+          case bytes
+          case token
+          case logprob
+          case topLogprobs = "top_logprobs"
+        }
+      }
+
+      case text(text: String, annotations: [Annotation], logprobs: [LogProb])
+      case refusal(String)
+
+      public var text: String {
+        switch self {
+        case let .text(text, _, _):
+          return text
+        case let .refusal(value):
+          return value
+        }
+      }
+
+      public var asText: String? {
+        if case let .text(text, _, _) = self {
+          return text
+        }
+        return nil
+      }
+    }
+
+    case message(Message.Output)
+    case functionCall(FunctionCall)
+    case functionCallOutput(FunctionCallOutput)
+    case reasoning(Reasoning)
+    case unknown(String)
+  }
+
+  public struct FunctionCall: Codable, Hashable, Sendable {
+    public enum Status: String, Codable, CaseIterable, Sendable {
+      case completed
+      case incomplete
+      case inProgress = "in_progress"
+    }
+
+    public var arguments: String
+    public var callId: String
+    public var id: String
+    public var name: String
+    public var status: Status
+
+    public init(arguments: String, callId: String, id: String, name: String, status: Status) {
+      self.arguments = arguments
+      self.callId = callId
+      self.id = id
+      self.name = name
+      self.status = status
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case arguments
+      case callId = "call_id"
+      case id
+      case name
+      case status
+    }
+  }
+
+  public struct FunctionCallOutput: Codable, Hashable, Sendable {
+    public var id: String?
+    public var status: Item.FunctionCall.Status?
+    public var callId: String
+    public var output: String
+
+    public init(id: String? = nil, status: Item.FunctionCall.Status? = nil, callId: String, output: String) {
+      self.id = id
+      self.status = status
+      self.callId = callId
+      self.output = output
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case id
+      case status
+      case callId = "call_id"
+      case output
+    }
+  }
+
+  public struct Reasoning: Codable, Hashable, Sendable {
+    public enum Status: String, Codable, CaseIterable, Sendable {
+      case completed
+      case incomplete
+      case inProgress = "in_progress"
+    }
+
+    public enum Summary: Codable, Hashable, Sendable {
+      case text(String)
+
+      public var text: String {
+        get {
+          switch self {
+          case let .text(value):
+            return value
+          }
+        }
+        set {
+          switch self {
+          case .text:
+            self = .text(newValue)
+          }
+        }
+      }
+
+    }
+
+    public var id: String
+    public var summary: [Summary]
+    public var status: Status?
+    public var encryptedContent: String?
+
+    public init(id: String, summary: [Summary] = [], status: Status? = nil, encryptedContent: String? = nil) {
+      self.id = id
+      self.summary = summary
+      self.status = status
+      self.encryptedContent = encryptedContent
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case id
+      case summary
+      case status
+      case encryptedContent = "encrypted_content"
+    }
+  }
+}
+
+// MARK: - Item.Input Codable
+
+extension Item.Input: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(typeIdentifier, forKey: .type)
+
+    switch self {
+    case let .inputMessage(message):
+      try message.encode(to: encoder)
+    case let .outputMessage(message):
+      try message.encode(to: encoder)
+    case let .functionCall(functionCall):
+      try functionCall.encode(to: encoder)
+    case let .functionCallOutput(output):
+      try output.encode(to: encoder)
+    case let .reasoning(reasoning):
+      try reasoning.encode(to: encoder)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    try self.init(from: decoder, type: type)
+  }
+
+  init(from decoder: Decoder, type: String) throws {
+    switch type {
+    case "message":
+      if let output = try? Message.Output(from: decoder) {
+        self = .outputMessage(output)
+      } else {
+        let input = try Message.Input(from: decoder)
+        self = .inputMessage(input)
+      }
+    case "function_call":
+      let functionCall = try FunctionCall(from: decoder)
+      self = .functionCall(functionCall)
+    case "function_call_output":
+      let output = try FunctionCallOutput(from: decoder)
+      self = .functionCallOutput(output)
+    case "reasoning":
+      let reasoning = try Reasoning(from: decoder)
+      self = .reasoning(reasoning)
+    default:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported item type \(type)."))
+    }
+  }
+}
+
+// MARK: - Item.Output Codable
+
+extension Item.Output: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .message(message):
+      try container.encode("message", forKey: .type)
+      try message.encode(to: encoder)
+    case let .functionCall(functionCall):
+      try container.encode("function_call", forKey: .type)
+      try functionCall.encode(to: encoder)
+    case let .functionCallOutput(output):
+      try container.encode("function_call_output", forKey: .type)
+      try output.encode(to: encoder)
+    case let .reasoning(reasoning):
+      try container.encode("reasoning", forKey: .type)
+      try reasoning.encode(to: encoder)
+    case let .unknown(type):
+      try container.encode(type, forKey: .type)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try? decoder.container(keyedBy: CodingKeys.self)
+    let type = try container?.decodeIfPresent(String.self, forKey: .type)
+
+    switch type {
+    case "message":
+      let message = try Message.Output(from: decoder)
+      self = .message(message)
+    case "function_call":
+      let call = try FunctionCall(from: decoder)
+      self = .functionCall(call)
+    case "function_call_output":
+      let output = try FunctionCallOutput(from: decoder)
+      self = .functionCallOutput(output)
+    case "reasoning":
+      let reasoning = try Reasoning(from: decoder)
+      self = .reasoning(reasoning)
+    case let .some(value):
+      self = .unknown(value)
+    case .none:
+      let message = try Message.Output(from: decoder)
+      self = .message(message)
+    }
+  }
+}
+
+// MARK: - Item.Output.Content Codable
+
+extension Item.Output.Content: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case text
+    case annotations
+    case logprobs
+    case refusal
+  }
+
+  private enum AnnotationCodingKeys: String, CodingKey {
+    case type
+    case fileId = "file_id"
+    case index
+    case endIndex = "end_index"
+    case startIndex = "start_index"
+    case title
+    case url
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .text(text, annotations, logprobs):
+      try container.encode("output_text", forKey: .type)
+      try container.encode(text, forKey: .text)
+      try container.encode(annotations, forKey: .annotations)
+      try container.encode(logprobs, forKey: .logprobs)
+    case let .refusal(refusal):
+      try container.encode("refusal", forKey: .type)
+      try container.encode(refusal, forKey: .refusal)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "output_text":
+      let text = try container.decode(String.self, forKey: .text)
+      let annotations = try container.decodeIfPresent([Annotation].self, forKey: .annotations) ?? []
+      let logprobs = try container.decodeIfPresent([LogProb].self, forKey: .logprobs) ?? []
+      self = .text(text: text, annotations: annotations, logprobs: logprobs)
+    case "refusal":
+      let refusal = try container.decode(String.self, forKey: .refusal)
+      self = .refusal(refusal)
+    default:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported output content type \(type)."))
+    }
+  }
+
+  private struct AnnotationWrapper: Codable, Hashable, Sendable {
+    var annotation: Annotation
+
+    init(annotation: Annotation) {
+      self.annotation = annotation
+    }
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: AnnotationCodingKeys.self)
+      let type = try container.decode(String.self, forKey: .type)
+      switch type {
+      case "file_citation":
+        let fileId = try container.decode(String.self, forKey: .fileId)
+        let index = try container.decode(UInt.self, forKey: .index)
+        annotation = .fileCitation(fileId: fileId, index: index)
+      case "url_citation":
+        let endIndex = try container.decode(UInt.self, forKey: .endIndex)
+        let startIndex = try container.decode(UInt.self, forKey: .startIndex)
+        let title = try container.decode(String.self, forKey: .title)
+        let url = try container.decode(String.self, forKey: .url)
+        annotation = .urlCitation(endIndex: endIndex, startIndex: startIndex, title: title, url: url)
+      case "file_path":
+        let fileId = try container.decode(String.self, forKey: .fileId)
+        let index = try container.decode(UInt.self, forKey: .index)
+        annotation = .filePath(fileId: fileId, index: index)
+      default:
+        throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported annotation type \(type)."))
+      }
+    }
+
+    func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: AnnotationCodingKeys.self)
+      switch annotation {
+      case let .fileCitation(fileId, index):
+        try container.encode("file_citation", forKey: .type)
+        try container.encode(fileId, forKey: .fileId)
+        try container.encode(index, forKey: .index)
+      case let .urlCitation(endIndex, startIndex, title, url):
+        try container.encode("url_citation", forKey: .type)
+        try container.encode(endIndex, forKey: .endIndex)
+        try container.encode(startIndex, forKey: .startIndex)
+        try container.encode(title, forKey: .title)
+        try container.encode(url, forKey: .url)
+      case let .filePath(fileId, index):
+        try container.encode("file_path", forKey: .type)
+        try container.encode(fileId, forKey: .fileId)
+        try container.encode(index, forKey: .index)
+      }
+    }
+  }
+}
+
+extension Item.Output.Content.Annotation: Codable {
+  public init(from decoder: Decoder) throws {
+    let wrapper = try Item.Output.Content.AnnotationWrapper(from: decoder)
+    self = wrapper.annotation
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try Item.Output.Content.AnnotationWrapper(annotation: self).encode(to: encoder)
+  }
+}
+
+extension Item.Reasoning.Summary {
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case text
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .text(text):
+      try container.encode("summary_text", forKey: .type)
+      try container.encode(text, forKey: .text)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "summary_text":
+      let text = try container.decode(String.self, forKey: .text)
+      self = .text(text)
+    default:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported reasoning summary type \(type)."))
+    }
+  }
+}

--- a/Sources/OpenAIModels/Message.swift
+++ b/Sources/OpenAIModels/Message.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public enum Message: Sendable {
+  public enum Role: String, Codable, CaseIterable, Sendable {
+    case user
+    case system
+    case assistant
+    case developer
+  }
+
+  public enum Status: String, Codable, CaseIterable, Sendable {
+    case completed
+    case incomplete
+    case inProgress = "in_progress"
+  }
+
+  public enum MessageContent: Sendable {
+    case input(Input.Content)
+    case output([Item.Output.Content])
+  }
+
+  public struct Input: Codable, Hashable, Sendable {
+    public var role: Role
+    public var status: Status?
+    public var content: Input.Content
+
+    public init(role: Role = .user, content: Input.Content, status: Status? = nil) {
+      self.role = role
+      self.status = status
+      self.content = content
+    }
+
+    public var text: String? {
+      content.text
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case role
+      case status
+      case content
+    }
+  }
+
+  public struct Output: Codable, Hashable, Sendable {
+    public var content: [Item.Output.Content]
+    public var id: String
+    public var role: Role
+    public var status: Status
+
+    public init(content: [Item.Output.Content], id: String, role: Role = .assistant, status: Status) {
+      self.content = content
+      self.id = id
+      self.role = role
+      self.status = status
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case content
+      case id
+      case role
+      case status
+    }
+
+    public var text: String {
+      content.map { $0.text }.joined()
+    }
+  }
+
+  case input(Input)
+  case output(Output)
+
+  public var role: Role {
+    switch self {
+    case let .input(message):
+      return message.role
+    case let .output(message):
+      return message.role
+    }
+  }
+
+  public var content: MessageContent {
+    switch self {
+    case let .input(message):
+      return .input(message.content)
+    case let .output(message):
+      return .output(message.content)
+    }
+  }
+
+  public var status: Status? {
+    switch self {
+    case let .input(message):
+      return message.status
+    case let .output(message):
+      return message.status
+    }
+  }
+
+  public var id: String? {
+    switch self {
+    case .input:
+      return nil
+    case let .output(message):
+      return message.id
+    }
+  }
+
+  public var text: String? {
+    switch self {
+    case let .input(message):
+      return message.text
+    case let .output(message):
+      return message.text
+    }
+  }
+}

--- a/Sources/OpenAIModels/Model.swift
+++ b/Sources/OpenAIModels/Model.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Identifiers for models that can be used with the OpenAI Responses API.
+public enum Model: Hashable, Sendable {
+  case o1
+  case o1Pro
+  case o1Mini
+  case o3
+  case o3Pro
+  case o3Mini
+  case o3DeepResearch
+  case o4Mini
+  case o4MiniDeepResearch
+  case codexMini
+  case gpt4
+  case gpt4Turbo
+  case gpt4o
+  case gpt4oMini
+  case gpt4_1
+  case gpt4_1Mini
+  case gpt4_1Nano
+  case gpt4_5Preview
+  case gpt3_5Turbo
+  case chatGPT4o
+  case computerUsePreview
+  case gpt5
+  case gpt5_mini
+  case gpt5_nano
+  case other(String)
+
+  public init(_ rawValue: String) {
+    switch rawValue {
+    case "o1": self = .o1
+    case "o1-pro": self = .o1Pro
+    case "o1-mini": self = .o1Mini
+    case "o3": self = .o3
+    case "o3-pro": self = .o3Pro
+    case "o3-mini": self = .o3Mini
+    case "o3-deep-research": self = .o3DeepResearch
+    case "o4-mini": self = .o4Mini
+    case "o4-mini-deep-research": self = .o4MiniDeepResearch
+    case "codex-mini": self = .codexMini
+    case "gpt-4": self = .gpt4
+    case "gpt-4o": self = .gpt4o
+    case "gpt-4o-mini": self = .gpt4oMini
+    case "gpt-4o-turbo": self = .gpt4Turbo
+    case "gpt-4.1": self = .gpt4_1
+    case "gpt-4.1-mini": self = .gpt4_1Mini
+    case "gpt-4.1-nano": self = .gpt4_1Nano
+    case "gpt-4.5-preview": self = .gpt4_5Preview
+    case "gpt-3.5-turbo": self = .gpt3_5Turbo
+    case "chatgpt-4o": self = .chatGPT4o
+    case "computer-use-preview": self = .computerUsePreview
+    case "gpt-5": self = .gpt5
+    case "gpt-5-mini": self = .gpt5_mini
+    case "gpt-5-nano": self = .gpt5_nano
+    default: self = .other(rawValue)
+    }
+  }
+
+  public var rawValue: String {
+    switch self {
+    case .o1: "o1"
+    case .o1Pro: "o1-pro"
+    case .o1Mini: "o1-mini"
+    case .o3: "o3"
+    case .o3Pro: "o3-pro"
+    case .o3Mini: "o3-mini"
+    case .o3DeepResearch: "o3-deep-research"
+    case .o4Mini: "o4-mini"
+    case .o4MiniDeepResearch: "o4-mini-deep-research"
+    case .codexMini: "codex-mini"
+    case .gpt4: "gpt-4"
+    case .gpt4Turbo: "gpt-4o-turbo"
+    case .gpt4o: "gpt-4o"
+    case .gpt4oMini: "gpt-4o-mini"
+    case .gpt4_1: "gpt-4.1"
+    case .gpt4_1Mini: "gpt-4.1-mini"
+    case .gpt4_1Nano: "gpt-4.1-nano"
+    case .gpt4_5Preview: "gpt-4.5-preview"
+    case .gpt3_5Turbo: "gpt-3.5-turbo"
+    case .chatGPT4o: "chatgpt-4o"
+    case .computerUsePreview: "computer-use-preview"
+    case .gpt5: "gpt-5"
+    case .gpt5_mini: "gpt-5-mini"
+    case .gpt5_nano: "gpt-5-nano"
+    case let .other(value): value
+    }
+  }
+}
+
+extension Model: RawRepresentable {
+  public init?(rawValue: String) {
+    self.init(rawValue)
+  }
+}
+
+extension Model: Codable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let value = try container.decode(String.self)
+    self.init(value)
+  }
+}

--- a/Sources/OpenAIModels/ReasoningConfig.swift
+++ b/Sources/OpenAIModels/ReasoningConfig.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Configuration options for reasoning capable models.
+public struct ReasoningConfig: Codable, Hashable, Sendable {
+  public enum Effort: String, Codable, CaseIterable, Sendable {
+    case minimal
+    case low
+    case medium
+    case high
+  }
+
+  public enum SummaryConfig: String, Codable, CaseIterable, Sendable {
+    case auto
+    case concise
+    case detailed
+  }
+
+  public var effort: Effort?
+  public var summary: SummaryConfig?
+
+  public init(effort: Effort? = nil, summary: SummaryConfig? = nil) {
+    self.effort = effort
+    self.summary = summary
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case effort
+    case summary
+  }
+}
+
+/// The truncation strategy to apply when inputs exceed the context window.
+public enum Truncation: String, Codable, CaseIterable, Sendable {
+  case auto
+  case disabled
+}
+
+/// The latency tier to use when processing a request.
+public enum ServiceTier: String, Codable, CaseIterable, Sendable {
+  case auto
+  case `default`
+  case flex
+  case priority
+}
+
+/// Reference to a reusable prompt template stored on the OpenAI platform.
+public struct Prompt: Codable, Hashable, Sendable {
+  public var id: String
+  public var version: String?
+  public var variables: [String: String]?
+
+  public init(id: String, version: String? = nil, variables: [String: String]? = nil) {
+    self.id = id
+    self.version = version
+    self.variables = variables
+  }
+}

--- a/Sources/OpenAIModels/Request.swift
+++ b/Sources/OpenAIModels/Request.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Request payload for the Responses API.
+public struct Request: Codable, Sendable {
+  public enum Include: String, Codable, CaseIterable, Sendable {
+    case codeInterpreterOutputs = "code_interpreter_call.outputs"
+    case computerCallImageURLs = "computer_call_output.output.image_url"
+    case fileSearchResults = "file_search_call.results"
+    case inputImageURLs = "message.input_image.image_url"
+    case outputLogprobs = "message.output_text.logprobs"
+    case encryptedReasoning = "reasoning.encrypted_content"
+  }
+
+  public var model: Model
+  public var input: Input
+  public var background: Bool?
+  public var include: [Include]?
+  public var instructions: String?
+  public var maxOutputTokens: UInt?
+  public var maxToolCalls: UInt?
+  public var metadata: [String: String]?
+  public var parallelToolCalls: Bool?
+  public var previousResponseId: String?
+  public var prompt: Prompt?
+  public var promptCacheKey: String?
+  public var reasoning: ReasoningConfig?
+  public var safetyIdentifier: String?
+  public var serviceTier: ServiceTier?
+  public var store: Bool?
+  public var stream: Bool?
+  public var temperature: Double?
+  public var text: TextConfig?
+  public var toolChoice: Tool.Choice?
+  public var tools: [Tool]?
+  public var topLogprobs: UInt?
+  public var topP: Double?
+  public var truncation: Truncation?
+  public var user: String?
+
+  public init(
+    model: Model,
+    input: Input,
+    background: Bool? = nil,
+    include: [Include]? = nil,
+    instructions: String? = nil,
+    maxOutputTokens: UInt? = nil,
+    maxToolCalls: UInt? = nil,
+    metadata: [String: String]? = nil,
+    parallelToolCalls: Bool? = nil,
+    previousResponseId: String? = nil,
+    prompt: Prompt? = nil,
+    promptCacheKey: String? = nil,
+    reasoning: ReasoningConfig? = nil,
+    safetyIdentifier: String? = nil,
+    serviceTier: ServiceTier? = nil,
+    store: Bool? = nil,
+    stream: Bool? = nil,
+    temperature: Double? = nil,
+    text: TextConfig? = nil,
+    toolChoice: Tool.Choice? = nil,
+    tools: [Tool]? = nil,
+    topLogprobs: UInt? = nil,
+    topP: Double? = nil,
+    truncation: Truncation? = nil,
+    user: String? = nil
+  ) {
+    self.model = model
+    self.input = input
+    self.background = background
+    self.include = include
+    self.instructions = instructions
+    self.maxOutputTokens = maxOutputTokens
+    self.maxToolCalls = maxToolCalls
+    self.metadata = metadata
+    self.parallelToolCalls = parallelToolCalls
+    self.previousResponseId = previousResponseId
+    self.prompt = prompt
+    self.promptCacheKey = promptCacheKey
+    self.reasoning = reasoning
+    self.safetyIdentifier = safetyIdentifier
+    self.serviceTier = serviceTier
+    self.store = store
+    self.stream = stream
+    self.temperature = temperature
+    self.text = text
+    self.toolChoice = toolChoice
+    self.tools = tools
+    self.topLogprobs = topLogprobs
+    self.topP = topP
+    self.truncation = truncation
+    self.user = user
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case model
+    case input
+    case background
+    case include
+    case instructions
+    case maxOutputTokens = "max_output_tokens"
+    case maxToolCalls = "max_tool_calls"
+    case metadata
+    case parallelToolCalls = "parallel_tool_calls"
+    case previousResponseId = "previous_response_id"
+    case prompt
+    case promptCacheKey = "prompt_cache_key"
+    case reasoning
+    case safetyIdentifier = "safety_identifier"
+    case serviceTier = "service_tier"
+    case store
+    case stream
+    case temperature
+    case text
+    case toolChoice = "tool_choice"
+    case tools
+    case topLogprobs = "top_logprobs"
+    case topP = "top_p"
+    case truncation
+    case user
+  }
+}

--- a/Sources/OpenAIModels/Response.swift
+++ b/Sources/OpenAIModels/Response.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// A response returned by the Responses API.
+public struct Response: Codable, Identifiable, Sendable {
+  public struct Usage: Codable, Hashable, Sendable {
+    public struct InputTokensDetails: Codable, Hashable, Sendable {
+      public var cachedTokens: UInt
+
+      public init(cachedTokens: UInt) {
+        self.cachedTokens = cachedTokens
+      }
+
+      private enum CodingKeys: String, CodingKey {
+        case cachedTokens = "cached_tokens"
+      }
+    }
+
+    public struct OutputTokensDetails: Codable, Hashable, Sendable {
+      public var reasoningTokens: UInt
+
+      public init(reasoningTokens: UInt) {
+        self.reasoningTokens = reasoningTokens
+      }
+
+      private enum CodingKeys: String, CodingKey {
+        case reasoningTokens = "reasoning_tokens"
+      }
+    }
+
+    public var inputTokens: UInt
+    public var inputTokensDetails: InputTokensDetails
+    public var outputTokens: UInt
+    public var outputTokensDetails: OutputTokensDetails
+    public var totalTokens: UInt
+
+    public init(
+      inputTokens: UInt,
+      inputTokensDetails: InputTokensDetails,
+      outputTokens: UInt,
+      outputTokensDetails: OutputTokensDetails,
+      totalTokens: UInt
+    ) {
+      self.inputTokens = inputTokens
+      self.inputTokensDetails = inputTokensDetails
+      self.outputTokens = outputTokens
+      self.outputTokensDetails = outputTokensDetails
+      self.totalTokens = totalTokens
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case inputTokens = "input_tokens"
+      case inputTokensDetails = "input_tokens_details"
+      case outputTokens = "output_tokens"
+      case outputTokensDetails = "output_tokens_details"
+      case totalTokens = "total_tokens"
+    }
+  }
+
+  public var id: String
+  public var output: [Item.Output]
+  public var usage: Usage?
+
+  public init(id: String, output: [Item.Output], usage: Usage? = nil) {
+    self.id = id
+    self.output = output
+    self.usage = usage
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case output
+    case usage
+  }
+}

--- a/Sources/OpenAIModels/TextConfig.swift
+++ b/Sources/OpenAIModels/TextConfig.swift
@@ -1,0 +1,55 @@
+import Foundation
+import FoundationModels
+
+/// Configuration options for text outputs from the Responses API.
+public struct TextConfig: Codable, Hashable, Sendable {
+  public enum Format: Hashable, Sendable {
+    case text
+    case generationSchema(schema: GenerationSchema, description: String? = nil, name: String, strict: Bool?)
+
+    private enum CodingKeys: String, CodingKey {
+      case type
+      case schema
+      case description
+      case name
+      case strict
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      switch self {
+      case .text:
+        try container.encode("text", forKey: .type)
+      case let .generationSchema(schema, description, name, strict):
+        try container.encode("json_schema", forKey: .type)
+        try container.encode(schema, forKey: .schema)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(strict, forKey: .strict)
+      }
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let type = try container.decode(String.self, forKey: .type)
+      switch type {
+      case "text":
+        self = .text
+      case "json_schema":
+        let schema = try container.decode(GenerationSchema.self, forKey: .schema)
+        let description = try container.decodeIfPresent(String.self, forKey: .description)
+        let name = try container.decode(String.self, forKey: .name)
+        let strict = try container.decodeIfPresent(Bool.self, forKey: .strict)
+        self = .generationSchema(schema: schema, description: description, name: name, strict: strict)
+      default:
+        throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported text format \(type)."))
+      }
+    }
+  }
+
+  public var format: Format
+
+  public init(format: Format = .text) {
+    self.format = format
+  }
+}

--- a/Sources/OpenAIModels/Tool.swift
+++ b/Sources/OpenAIModels/Tool.swift
@@ -1,0 +1,114 @@
+import Foundation
+import FoundationModels
+
+/// Tools that the model may invoke while generating a response.
+public struct Tool: Codable, Hashable, Sendable {
+  public struct Function: Codable, Hashable, Sendable {
+    public var name: String
+    public var description: String?
+    public var parameters: GenerationSchema
+    public var strict: Bool
+
+    public init(name: String, description: String? = nil, parameters: GenerationSchema, strict: Bool = true) {
+      self.name = name
+      self.description = description
+      self.parameters = parameters
+      self.strict = strict
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case name
+      case description
+      case parameters
+      case strict
+    }
+  }
+
+  public enum Choice: Hashable, Sendable {
+    case auto
+    case none
+    case required
+    case function(name: String)
+
+    private enum CodingKeys: String, CodingKey {
+      case type
+      case function
+    }
+
+    private enum FunctionCodingKeys: String, CodingKey {
+      case name
+    }
+  }
+
+  public var type: String
+  public var function: Function?
+
+  public init(type: String, function: Function? = nil) {
+    self.type = type
+    self.function = function
+  }
+
+  public static func function(
+    name: String,
+    description: String?,
+    parameters: GenerationSchema,
+    strict: Bool
+  ) -> Tool {
+    Tool(type: "function", function: Function(name: name, description: description, parameters: parameters, strict: strict))
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case function
+  }
+}
+
+extension Tool.Choice: Codable {
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case .auto:
+      var container = encoder.singleValueContainer()
+      try container.encode("auto")
+    case .none:
+      var container = encoder.singleValueContainer()
+      try container.encode("none")
+    case .required:
+      var container = encoder.singleValueContainer()
+      try container.encode("required")
+    case let .function(name):
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode("function", forKey: .type)
+      var functionContainer = container.nestedContainer(keyedBy: FunctionCodingKeys.self, forKey: .function)
+      try functionContainer.encode(name, forKey: .name)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    if let singleValue = try? decoder.singleValueContainer() {
+      if let raw = try? singleValue.decode(String.self) {
+        switch raw {
+        case "auto":
+          self = .auto
+        case "none":
+          self = .none
+        case "required":
+          self = .required
+        default:
+          throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported tool choice \(raw)."))
+        }
+        return
+      }
+    }
+
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "function":
+      let nested = try container.nestedContainer(keyedBy: FunctionCodingKeys.self, forKey: .function)
+      let name = try nested.decode(String.self, forKey: .name)
+      self = .function(name: name)
+    default:
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unsupported tool choice \(type)."))
+    }
+  }
+}

--- a/SwiftAgent.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftAgent.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,15 +29,6 @@
       }
     },
     {
-      "identity" : "swift-openai-responses",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftedMind/swift-openai-responses",
-      "state" : {
-        "branch" : "main",
-        "revision" : "e61ca50bf98d4e8bcbb713ea52865d10b0076317"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",


### PR DESCRIPTION
## Summary
- add a new OpenAI target that defines native Codable models for requests, responses, and transcript items used by the adapter
- update the package manifest and resolved files to depend on the internal OpenAI target instead of the swift-openai-responses package

## Testing
- not run (XcodeBuildMCP is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d15b359e9483208a5207805cd7487f