### PR TITLE
feat(agent): add resolved transcript support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
 ### Enhanced
 - **MacPaw OpenAI SDK Migration**: Adopted MacPaw's `OpenAI` Swift package for request execution and removed the `MetaCodable` macro dependency, simplifying adapter maintenance and eliminating macro build overhead.
 - **Code Cleanup**: Removed unused `Array<PromptContextLinkPreview>` extension that was adding unnecessary complexity to the prompt context API surface.
-- **Tool Error Type Rename**: Renamed the core tool error type to `ToolRunError` (`Sources/SwiftAgent/Agent/ToolRunError.swift`) so recoverable problems stay separate from fatal failures and the agent loop only stops when necessary.
+- **Tool Error Type Rename**: Renamed the core tool error type to `ToolRunError`.
+- **Improved Tool Resolution**: Introduced the `AgentTranscript.Resolved` type for embedding tool runs directly into a transcript you can iterate over. You can access it through `transcript.resolved(using: tools)`.
 
 ### Fixed
 

--- a/Examples/Example App/ExampleApp/RootView.swift
+++ b/Examples/Example App/ExampleApp/RootView.swift
@@ -136,7 +136,21 @@ struct RootView: View {
 
 			agentResponse = response.content
 			userInput = ""
-
+			
+			for test in session.transcript.resolved(using: tools) {
+				switch test {
+				case .toolRun(let toolRun):
+					switch toolRun {
+					case .calculator(let agentToolRun):
+						break
+					case .weather(let agentToolRun):
+						break
+					}
+				default:
+					break
+				}
+			}
+			
 			let toolResolver = session.transcript.toolResolver(for: tools)
 			for entry in response.addedEntries {
 				if case let .toolCalls(toolCalls) = entry {

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ for entry in session.transcript {
   if case let .toolCalls(toolCalls) = entry {
     for toolCall in toolCalls {
       let resolvedTool = try toolResolver.resolve(toolCall)
-      
+
       switch resolvedTool {
       case let .weather(run):
         print("Weather for: \(run.arguments.city)")
@@ -280,6 +280,32 @@ for entry in session.transcript {
   }
 }
 ```
+
+#### Resolved Transcript View
+
+When you want resolved tool runs directly alongside transcript entries, create a resolved view:
+
+```swift
+let resolvedTranscript = session.transcript.resolvingTools(with: tools)
+
+for entry in resolvedTranscript {
+  switch entry {
+  case let .toolRun(toolRun):
+    if let resolved = try? toolRun.get() {
+      print("Tool \(toolRun.call.toolName) succeeded with: \(resolved)")
+    } else if let error = toolRun.error {
+      print("Tool \(toolRun.call.toolName) failed: \(error)")
+    }
+  default:
+    break
+  }
+}
+
+// Access the original transcript at any time
+resolvedTranscript.transcript
+```
+
+This additive view keeps the provider transcript intact while progressively layering on resolved tool runs, so opting out is as easy as working with `AgentTranscript` directly.
 
 ### Structured Output Generation
 

--- a/Sources/SwiftAgent/Agent/AgentToolResolver.swift
+++ b/Sources/SwiftAgent/Agent/AgentToolResolver.swift
@@ -37,7 +37,8 @@ public extension AgentTranscript {
 	///   }
 	/// }
 	/// ```
-	func toolResolver<ResolvedToolRun>(for tools: [any AgentTool<ResolvedToolRun>]) -> AgentToolResolver<Context, ResolvedToolRun> {
+	func toolResolver<ResolvedToolRun>(for tools: [any AgentTool<ResolvedToolRun>])
+		-> AgentToolResolver<Context, ResolvedToolRun> {
 		AgentToolResolver(tools: tools, in: self)
 	}
 }
@@ -87,6 +88,9 @@ public extension AgentTranscript {
 ///   }
 /// }
 /// ```
+///
+/// - Tip: Use ``AgentTranscript/resolvingTools(with:)`` when you want resolved tool runs to appear
+///   alongside transcript entries without manually managing a resolver instance.
 ///
 /// ## Error Handling
 ///
@@ -163,7 +167,7 @@ public struct AgentToolResolver<Context: PromptContextSource, ResolvedToolRun> {
 			let availableTools = toolsByName.keys.sorted().joined(separator: ", ")
 			AgentLog.error(
 				AgentToolResolutionError.unknownTool(name: call.toolName),
-				context: "Tool resolution failed. Available tools: \(availableTools)",
+				context: "Tool resolution failed. Available tools: \(availableTools)"
 			)
 			throw AgentToolResolutionError.unknownTool(name: call.toolName)
 		}
@@ -187,8 +191,7 @@ public struct AgentToolResolver<Context: PromptContextSource, ResolvedToolRun> {
 	/// - Parameter call: The tool call to find output for
 	/// - Returns: The generated content from the tool's output, or `nil` if no output found
 	private func findOutput(for call: ToolCall) -> GeneratedContent? {
-		guard let toolOutput = transcriptToolOutputs.first(
-			where: { $0.callId == call.callId }) else {
+		guard let toolOutput = transcriptToolOutputs.first(where: { $0.callId == call.callId }) else {
 			return nil
 		}
 

--- a/Sources/SwiftAgent/Agent/AgentTranscript+Resolved.swift
+++ b/Sources/SwiftAgent/Agent/AgentTranscript+Resolved.swift
@@ -1,0 +1,141 @@
+// By Dennis Müller
+
+import Foundation
+import FoundationModels
+
+public extension AgentTranscript {
+	/// Builds a *resolved transcript* — an immutable, read‑only **projection** of this transcript in which
+	/// tool‑related events are materialized as strongly-typed runs.
+	///
+	/// ### What it does
+	/// - Walks the original entries in order.
+	/// - Converts `.toolCalls` into one or more `.toolRun` entries by resolving each call with one
+	///   of the supplied tools.
+	/// - Coalesces related `.toolOutput` items into the resulting `.toolRun` and does **not** surface
+	///   separate `.toolOutput` entries in the projection.
+	///
+	/// ### When to use it
+	/// Use this when you want to *render* or *inspect* tool results in a type‑safe way without
+	/// mutating or duplicating transcript state.
+	///
+	/// ### Failure
+	/// Returns `nil` if any tool call cannot be resolved with the provided tools (for example,
+	/// no matching tool by name, or decoding arguments failed).
+	///
+	/// ### Example
+	/// ```swift
+	/// if let resolved = transcript.resolved(using: tools) {
+	///   for entry in resolved {
+	///     switch entry {
+	///     case let .toolRun(run):
+	///       render(run.resolution)
+	///     default:
+	///       break
+	///     }
+	///   }
+	/// }
+	/// ```
+	///
+	/// - Parameter tools: The tools available during resolution. All must share the same resolution type.
+	/// - Returns: A read‑only projection that layers resolved tool runs over the original entries, or `nil` on failure.
+	func resolved<ResolvedToolRun>(using tools: [any AgentTool<ResolvedToolRun>]) -> Resolved<ResolvedToolRun>? {
+		try? Resolved(transcript: self, tools: tools)
+	}
+
+	/// An immutable **projection** of a transcript with tool runs resolved.
+	///
+	/// You can obtain instances via ``AgentTranscript/resolved(using:)``.
+	struct Resolved<ResolutionType> {
+		/// All transcript entries with resolved tool runs attached where available.
+		public package(set) var entries: [Entry]
+
+		init(transcript: AgentTranscript<Context>, tools: [any AgentTool<ResolutionType>]) throws {
+			let resolver = AgentToolResolver(tools: tools, in: transcript)
+			entries = []
+
+			for entry in transcript.entries {
+				switch entry {
+				case let .prompt(prompt):
+					entries.append(.prompt(prompt))
+				case let .reasoning(reasoning):
+					entries.append(.reasoning(reasoning))
+				case let .response(response):
+					entries.append(.response(response))
+				case let .toolCalls(toolCalls):
+					for call in toolCalls {
+						let resolution = try resolver.resolve(call)
+						entries.append(.toolRun(.init(call: call, resolution: resolution)))
+					}
+				case .toolOutput:
+					// Handled already by the .toolCalls cases
+					break
+				}
+			}
+		}
+
+		/// Transcript entry augmented with resolved tool runs.
+		public enum Entry: Identifiable {
+			case prompt(AgentTranscript<Context>.Prompt)
+			case reasoning(AgentTranscript<Context>.Reasoning)
+			case toolRun(ResolvedToolRun)
+			case response(AgentTranscript<Context>.Response)
+
+			public var id: String {
+				switch self {
+				case let .prompt(prompt):
+					prompt.id
+				case let .reasoning(reasoning):
+					reasoning.id
+				case let .toolRun(toolRun):
+					toolRun.id
+				case let .response(response):
+					response.id
+				}
+			}
+		}
+
+		/// A resolved tool run.
+		public struct ResolvedToolRun: Identifiable {
+			private let call: AgentTranscript<Context>.ToolCall
+
+			/// The identifier of this run.
+			public var id: String { call.id }
+
+			/// The tool resolution.
+			public let resolution: ResolutionType
+
+			/// The tool name captured within the original call, convenient for switching logic.
+			public var toolName: String { call.toolName }
+
+			init(call: AgentTranscript<Context>.ToolCall, resolution: ResolutionType) {
+				self.call = call
+				self.resolution = resolution
+			}
+		}
+	}
+}
+
+extension AgentTranscript.Resolved: RandomAccessCollection, RangeReplaceableCollection {
+	public var startIndex: Int { entries.startIndex }
+	public var endIndex: Int { entries.endIndex }
+
+	public init() {
+		entries = []
+	}
+
+	public subscript(position: Int) -> Entry {
+		entries[position]
+	}
+
+	public func index(after i: Int) -> Int {
+		entries.index(after: i)
+	}
+
+	public func index(before i: Int) -> Int {
+		entries.index(before: i)
+	}
+
+	public mutating func replaceSubrange(_ subrange: Range<Int>, with newElements: some Collection<Entry>) {
+		entries.replaceSubrange(subrange, with: newElements)
+	}
+}

--- a/Sources/SwiftAgent/Agent/AgentTranscript.swift
+++ b/Sources/SwiftAgent/Agent/AgentTranscript.swift
@@ -72,7 +72,7 @@ public extension AgentTranscript {
 			id: String = UUID().uuidString,
 			input: String,
 			context: PromptContext<Context> = .empty,
-			embeddedPrompt: String
+			embeddedPrompt: String,
 		) {
 			self.id = id
 			self.input = input
@@ -91,7 +91,7 @@ public extension AgentTranscript {
 			id: String,
 			summary: [String],
 			encryptedReasoning: String?,
-			status: Status? = nil
+			status: Status? = nil,
 		) {
 			self.id = id
 			self.summary = summary
@@ -144,7 +144,7 @@ extension AgentTranscript.ToolCalls: RandomAccessCollection, RangeReplaceableCol
 
 	public mutating func replaceSubrange(
 		_ subrange: Range<Int>,
-		with newElements: some Collection<AgentTranscript<Context>.ToolCall>
+		with newElements: some Collection<AgentTranscript<Context>.ToolCall>,
 	) {
 		calls.replaceSubrange(subrange, with: newElements)
 	}
@@ -163,7 +163,7 @@ public extension AgentTranscript {
 			callId: String,
 			toolName: String,
 			arguments: GeneratedContent,
-			status: Status?
+			status: Status?,
 		) {
 			self.id = id
 			self.callId = callId
@@ -185,7 +185,7 @@ public extension AgentTranscript {
 			callId: String,
 			toolName: String,
 			segment: Segment,
-			status: Status?
+			status: Status?,
 		) {
 			self.id = id
 			self.callId = callId
@@ -203,7 +203,7 @@ public extension AgentTranscript {
 		public init(
 			id: String,
 			segments: [Segment],
-			status: Status
+			status: Status,
 		) {
 			self.id = id
 			self.segments = segments
@@ -248,106 +248,5 @@ public extension AgentTranscript {
 			self.id = id
 			self.content = content.generatedContent
 		}
-	}
-}
-
-public extension AgentTranscript {
-	/// Returns a transcript view with resolved tool runs attached to each tool call entry.
-	///
-	/// This method provides a progressive enhancement on top of the base transcript. When you
-	/// need strongly typed tool results, call this method to receive a typed view while keeping
-	/// the underlying transcript unchanged. If you do not need tool resolution, simply work with
-	/// ``AgentTranscript`` directly—no additional generics or APIs get in the way.
-	///
-	/// - Parameter tools: The tools used during the session, sharing the same `ResolvedToolRun` type.
-	/// - Returns: A resolved transcript view that preserves the original entries and adds resolved runs.
-	func resolved<ResolvedToolRun>(using tools: [any AgentTool<ResolvedToolRun>]) -> Resolved<ResolvedToolRun> {
-		Resolved(transcript: self, tools: tools)
-	}
-
-	/// A transcript view that augments tool call entries with resolved tool runs.
-	///
-	/// The resolved transcript keeps the original transcript intact for full reproduction of the
-	/// provider conversation, while offering type-safe access to resolved tool runs alongside each
-	/// tool call.
-	struct Resolved<ResolvedToolRun> {
-		/// The original transcript that backs this view.
-		public let originalTranscript: AgentTranscript<Context>
-
-		/// All transcript entries with resolved tool runs attached where available.
-		public package(set) var entries: [Entry]
-
-		init(transcript: AgentTranscript<Context>, tools: [any AgentTool<ResolvedToolRun>]) {
-			self.originalTranscript = transcript
-			let resolver = AgentToolResolver(tools: tools, in: transcript)
-			self.entries = []
-			
-			for entry in transcript.entries {
-				switch entry {
-				case let .prompt(prompt):
-					entries.append(.prompt(prompt))
-				case let .reasoning(reasoning):
-					entries.append(.reasoning(reasoning))
-				case let .response(response):
-					entries.append(.response(response))
-				case let .toolCalls(toolCalls):
-					for call in toolCalls {
-						let resolvedToolRun = try! resolver.resolve(call)
-						entries.append(.toolRun(resolvedToolRun))
-					}
-				case .toolOutput:
-					// Handled already by the .toolCalls cases
-					break
-				}
-			}
-		}
-
-		/// Transcript entry augmented with resolved tool runs.
-		public enum Entry: Identifiable {
-			case prompt(AgentTranscript<Context>.Prompt)
-			case reasoning(AgentTranscript<Context>.Reasoning)
-			case toolRun(ResolvedToolRun)
-			case response(AgentTranscript<Context>.Response)
-
-			public var id: String {
-				switch self {
-				case let .prompt(prompt):
-					prompt.id
-				case let .reasoning(reasoning):
-					reasoning.id
-				case let .toolRun(toolRun):
-					// TODO: Fix this
-					"toolRun.id"
-				case let .response(response):
-					response.id
-				}
-			}
-		}
-	}
-}
-
-extension AgentTranscript.Resolved: RandomAccessCollection, RangeReplaceableCollection {
-	public var startIndex: Int { entries.startIndex }
-	public var endIndex: Int { entries.endIndex }
-
-	public init() {
-		entries = []
-		self.originalTranscript = AgentTranscript()
-	}
-	
-	public subscript(position: Int) -> Entry {
-		entries[position]
-	}
-
-	public func index(after i: Int) -> Int {
-		entries.index(after: i)
-	}
-
-	public func index(before i: Int) -> Int {
-		entries.index(before: i)
-	}
-	
-	public mutating func replaceSubrange(_ subrange: Range<Int>, with newElements: some Collection<Entry>) {
-		entries.replaceSubrange(subrange, with: newElements)
 	}
 }


### PR DESCRIPTION
## Summary
- add AgentTranscript.Resolved to merge tool runs directly into the transcript
- update README sample and ExampleApp to use the resolved transcript API
- document the new functionality in the changelog and format touched files

## Testing
- XcodeBuildMCP.build_sim (scheme: SwiftAgent, simulator: iPhone 16 Pro)
