### PR TITLE
Add isError/cacheControl labels to .toolResult call (SwiftAnthropic 2.2.2)

### DIFF
--- a/Sources/AnthropicSession/Helpers/AnthropicMessageBuilder.swift
+++ b/Sources/AnthropicSession/Helpers/AnthropicMessageBuilder.swift
@@ -102,7 +102,7 @@ enum AnthropicMessageBuilder {
 
         append(
           role: .user,
-          content: .toolResult(toolOutput.callId, output, nil, nil),
+          content: .toolResult(toolOutput.callId, output, isError: nil, cacheControl: nil),
         )
 
       case let .reasoning(reasoning):


### PR DESCRIPTION
SwiftAnthropic 2.2.2 added required argument labels (`isError:`, `cacheControl:`) to the `MessageParameter.Message.Content.ToolResult` enum case. Building SwiftAgent against the latest tag fails with:

```
Sources/AnthropicSession/Helpers/AnthropicMessageBuilder.swift:105:31:
error: missing argument labels 'isError:cacheControl:' in call
```

This one-line patch adds the labels at the single call site. Backwards-compatible with 2.2.0/2.2.1 (the labels were optional there). Discovered while shipping a downstream macOS app on the macOS 26 toolchain — happy to address review feedback.

## Test plan
- [ ] `xcodebuild -resolvePackageDependencies` succeeds against latest SwiftAnthropic
- [ ] Existing AnthropicSession tests still pass