### PR TITLE
Remove SimulatedSession from OpenAISession/AnthropicSession product bundles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,13 @@ let package = Package(
     .macOS(.v26),
   ],
   products: [
-    .library(name: "OpenAISession", targets: ["OpenAISession", "SimulatedSession", "SwiftAgent"]),
-    .library(name: "AnthropicSession", targets: ["AnthropicSession", "SimulatedSession", "SwiftAgent"]),
+    // NOTE (ADSwift fork): SimulatedSession removed from these product bundles.
+    // Its actor's sync init initializes a `var` property, which under
+    // Swift 6.2 conflicts with the Adapter protocol's sync-init requirement
+    // ('nonisolated' on an actor's synchronous initializer is invalid).
+    // Consumers who need SimulatedSession can depend on the target directly.
+    .library(name: "OpenAISession", targets: ["OpenAISession", "SwiftAgent"]),
+    .library(name: "AnthropicSession", targets: ["AnthropicSession", "SwiftAgent"]),
     .library(name: "ExampleCode", targets: ["ExampleCode"]),
   ],
   dependencies: [


### PR DESCRIPTION
Under Swift 6.2 (the package's declared `swift-tools-version`) on the macOS 26 toolchain, `SimulatedSession.SimulationAdapter` fails to compile:

```
Sources/SimulatedSession/SimulationAdapter.swift:25:10:
error: 'nonisolated' on an actor's synchronous initializer is invalid
```

The adapter is an `actor` whose sync init initializes a `var` property (`nextDefaultGenerationIndex`), which forces actor isolation on the init and conflicts with the `Adapter: Actor { init(...) }` protocol's nonisolated-init requirement. `OpenAIAdapter` and `AnthropicAdapter` are unaffected because they only initialize `let` properties (flow-isolated nonisolated is allowed).

This means consumers who depend on `OpenAISession` or `AnthropicSession` and don't need the simulation harness still pay the compile cost of `SimulatedSession` — and currently can't ship at all under Swift 6.2.

This patch drops `SimulatedSession` from the `OpenAISession`/`AnthropicSession` product bundles. The target still exists; consumers who do need it can depend on it directly. `ExampleCode` continues to pull it in.

This unblocks downstream apps on Swift 6.2 without touching the actor design itself (the Adapter protocol's sync init can be addressed separately if you want).

## Test plan
- [ ] Apps that don't import SimulatedSession build cleanly under Swift 6.2
- [ ] Apps that explicitly depend on SimulatedSession still get it
- [ ] Tests targeting SimulatedSession still run